### PR TITLE
Allow to pass the constructor replica sets for mongoskin.

### DIFF
--- a/mongo.js
+++ b/mongo.js
@@ -2,6 +2,7 @@ var _require = require;
 var mongoskin = _require('mongoskin');
 var assert = require('assert');
 var async = require('async');
+var util = require('util');
 
 var metaOperators = {
   $comment: true
@@ -36,7 +37,7 @@ var cursorOperators = {
  * var db = require('livedb-mongo')(skin);
  */
 exports = module.exports = function(mongo, options) {
-  if (typeof mongo !== 'object') {
+  if (util.isArray(mongo) || typeof mongo !== 'object') {
     mongo = mongoskin.db.apply(mongoskin.db, arguments);
   }
   return new LiveDbMongo(mongo, options);


### PR DESCRIPTION
When trying to pass a replica set configuration to mongoskin through the constructor it failed before. Now this is possible:

``` js
var db = livedbMongo(['localhost:27107', 'localhost:27108'], {database: 'sharejs'});
```

For an example from mongoskin see [here](https://github.com/kissjs/node-mongoskin/blob/master/examples/replSetBenchmark.js)
