### PR TITLE
Add an optional ttl index to expire ops

### DIFF
--- a/mongo.js
+++ b/mongo.js
@@ -215,21 +215,75 @@ LiveDbMongo.prototype.getVersion = function(cName, docName, callback) {
   });
 };
 
+// Exported for testing
+LiveDbMongo.prototype._readOps = function(cName, docName, start, end, callback) {
+  var query = end == null ? {$gte:start} : {$gte:start, $lt:end};
+  this._opCollection(cName).find({name:docName, v:query}, {sort:{v:1}}).toArray(callback);
+};
+
 LiveDbMongo.prototype.getOps = function(cName, docName, start, end, callback) {
   var err; if (err = this._check(cName)) return callback(err);
 
-  var query = end == null ? {$gte:start} : {$gte:start, $lt:end};
-  this._opCollection(cName).find({name:docName, v:query}, {sort:{v:1}}).toArray(function(err, data) {
-    if (err) return callback(err);
-
+  var retried = false;
+  var self = this;
+  
+  function retry() {
+    // First, attempt to get the requested ops from the op collection
+    self._readOps(cName, docName, start, end, function(err, data) {
+      if (err) return callback(err);
+      
+      // If we didn't get any ops, and we don't know the end of the range requested,
+      // then we need to get the document version to check if ops were expected.
+      if (data.length === 0 && end == null) {
+        // If we already retried (see below for why), 
+        // then ops are missing from the requested range.
+        if (retried)
+          return callback('Missing operations');
+        
+        // Get the current snapshot version
+        self.getVersion(cName, docName, function(err, v) {
+          if (err) return callback(err);
+          
+          // Race condition! If the version returned is greater than the start
+          // of the requested range (and we got no ops above), an op may have
+          // been submitted between when we got ops and when we got the version.
+          // Retry to get the missing ops.
+          if (v > start) {
+            retried = true;
+            retry();
+          } else {
+            done(data);
+          }
+        });
+      } else {
+        done(data);
+      }
+    });
+  }
+  
+  function done(data) {
+    // If we know the end of the requested op range, check that we got the right number.
+    if (end != null) {
+      var expectedLength = start >= end ? 0 : end - start;
+      if (data.length !== expectedLength)
+        return callback('Missing operations');
+    }
+        
+    var v = start;
     for (var i = 0; i < data.length; i++) {
+      // Check that we got ops in the right order with none missing.
+      if (data[i].v !== v++)
+        return callback('Missing operations');
+      
       // Strip out _id in the results
       delete data[i]._id;
       delete data[i].name;
     }
+    
     callback(null, data);
-  });
+  }
 
+  retry();
 };
 
 

--- a/test.coffee
+++ b/test.coffee
@@ -76,6 +76,100 @@ describe 'mongo', ->
           assert.equal v, 3
           done()
 
+    describe 'getOps', ->
+      it 'errors if ops are missing at the start of the range', (done) ->
+        @db.writeOp 'testcollection', 'test', {v:0, op:{test:1}}, (err) =>
+          throw Error err if err
+          @db.writeOp 'testcollection', 'test', {v:1, op:{test:2}}, (err) =>
+            throw Error err if err
+            
+            readOps = @db._readOps
+            @db._readOps = (cName, docName, start, end, callback) ->
+              readOps.call this, cName, docName, start, end, (err, ops) ->
+                callback err, ops.slice(1)
+              
+            @db.getOps 'testcollection', 'test', 0, null, (err, ops) =>
+              @db._readOps = readOps
+              assert.equal err, 'Missing operations'
+              done()
+              
+      it 'errors if ops are missing in the middle of the range', (done) ->
+        @db.writeOp 'testcollection', 'test', {v:0, op:{test:1}}, (err) =>
+          throw Error err if err
+          @db.writeOp 'testcollection', 'test', {v:1, op:{test:2}}, (err) =>
+            throw Error err if err
+            @db.writeOp 'testcollection', 'test', {v:2, op:{test:3}}, (err) =>
+              throw Error err if err
+            
+              readOps = @db._readOps
+              @db._readOps = (cName, docName, start, end, callback) ->
+                readOps.call this, cName, docName, start, end, (err, ops) ->
+                  callback err, [ops[0], ops[2]]
+              
+              @db.getOps 'testcollection', 'test', 0, null, (err, ops) =>
+                @db._readOps = readOps
+                assert.equal err, 'Missing operations'
+                done()
+                
+      it 'errors if ops are missing when end specified', (done) ->
+        @db.writeOp 'testcollection', 'test', {v:0, op:{test:1}}, (err) =>
+          throw Error err if err
+          @db.writeOp 'testcollection', 'test', {v:1, op:{test:2}}, (err) =>
+            throw Error err if err
+            
+            readOps = @db._readOps
+            @db._readOps = (cName, docName, start, end, callback) ->
+              readOps.call this, cName, docName, start, end, (err, ops) ->
+                callback err, ops.slice(1)
+              
+            @db.getOps 'testcollection', 'test', 0, 2, (err, ops) =>
+              @db._readOps = readOps
+              assert.equal err, 'Missing operations'
+              done()
+                
+      it 'errors if ops are missing when ops missing from range end', (done) ->
+        @db.writeOp 'testcollection', 'test', {v:0, op:{test:1}}, (err) =>
+          throw Error err if err
+              
+          @db.getOps 'testcollection', 'test', 0, 5, (err, ops) =>
+            assert.equal err, 'Missing operations'
+            done()
+            
+      it 'errors if there are no ops and snapshot version is larger than range start', (done) ->
+        @db.writeSnapshot 'testcollection', 'test', {type: 'json0', v: 3, data:{x:5}}, (err) =>
+          throw Error err if err
+          
+          @db.getOps 'testcollection', 'test', 0, null, (err, ops) =>
+            assert.equal err, 'Missing operations'
+            done()
+            
+      it 'handles race condition when ops are submitted at the same time as a getOps call', (done) ->
+        @db.writeSnapshot 'testcollection', 'test', {type: 'json0', v: 3, data:{x:5}}, (err) =>
+          throw Error err if err
+          
+          # simulate race condition by writing in getVersion
+          getVersion = @db.getVersion
+          @db.getVersion = (cName, docName, callback) ->
+            @writeOp 'testcollection', 'test', {v:3, op:{test:1}}, (err) =>
+              throw Error err if err
+              @getVersion = getVersion
+              @getVersion cName, docName, callback
+          
+          @db.getOps 'testcollection', 'test', 3, null, (err, ops) =>
+            throw Error err if err
+            assert.ok ops
+            assert.ok ops.length
+            done()
+            
+      it 'should return nothing if there are no ops, and version matches range start', (done) ->
+        @db.writeSnapshot 'testcollection', 'test', {type: 'json0', v: 3, data:{x:5}}, (err) =>
+          throw Error err if err
+          
+          @db.getOps 'testcollection', 'test', 3, null, (err, ops) =>
+            throw Error err if err
+            assert.ok ops
+            assert.equal ops.length, 0
+            done()
 
     describe 'query', ->
       it 'returns data in the collection', (done) ->


### PR DESCRIPTION
This is a revival of #7. It allows you to specify a `ttl` option to livedb-mongo to expire ops after a specified time period. I'm working on another PR for livedb to handle emitting the proper errors when requested ops are missing.  See https://github.com/share/livedb/pull/33.
