### PR TITLE
Implement `makeSortedQuery`, used in new sharedb tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -838,6 +838,22 @@ ShareDbMongo.prototype.checkQuery = function(query) {
   }
 };
 
+// XXX duplicated in sharedb-mingo-memory; should we extract to
+// sharedb-mongo-utilities?
+//
+// Given a key/value comparison query, return a query object with that
+// filter and a specified sort order. The 'order' argument looks like
+// [['foo', 1], ['bar', -1]] for sort by foo asending, then bar
+// descending
+ShareDbMongo.prototype.makeSortedQuery = function(query, order) {
+  // Convert order to Mongo's expected structure
+  var mongoOrder = {};
+  for (var i = 0; i < order.length; i++) {
+    mongoOrder[order[i][0]] = order[i][1];
+  }
+  return {$query: query, $orderby: mongoOrder};
+};
+
 function normalizeQuery(inputQuery) {
   // Box queries inside of a $query and clone so that we know where to look
   // for selctors and can modify them without affecting the original object

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^1.4.2",
     "mongodb": "^2.0.45",
-    "sharedb": "^0.11.6"
+    "sharedb": "avital/sharedb#use-mingo"
   },
   "devDependencies": {
     "coveralls": "^2.11.8",


### PR DESCRIPTION
The new sharedb tests rely on the in-memory DB driver used
to construct a sorted query object rather than assuming that
the format will be like in Mongo.

See https://github.com/share/sharedb/pull/84/commits/c87b02fcfd9ad7e935b483f2bd5183aef508d7d0