### PR TITLE
Deprecate $query, use cursor methods instead of dollar properties in queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,26 @@
 language: node_js
+
 node_js:
   - 5
   - 4
   - 0.10
-services: mongodb
+
+services:
+  - docker
+
+env:
+  - MONGODB_VERSION="2.4"
+  - MONGODB_VERSION="2.6"
+  - MONGODB_VERSION="3.0"
+  - MONGODB_VERSION="3.2"
+
+before_install:
+  - docker run -d -p 127.0.0.1:27017:27017 mongo:$MONGODB_VERSION
+
+before_script:
+  - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
+
 script: "npm run test-cover"
+
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Mongo errors are passed back directly. Additional error codes:
 * 4107 -- Unknown query operator
 * 4108 -- Only one collection operation allowed
 * 4109 -- Only one cursor operation allowed
-* 4110 -- Cursor method can't run after collection method
+* 4110 -- Cursor methods can't run after collection method
+* 4111 -- Malformed query operator
 
 #### 5100 -- Internal error - DB
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Mongo errors are passed back directly. Additional error codes:
 * 4105 -- $aggregate queries disabled
 * 4106 -- $query property deprecated in queries
 * 4107 -- Unknown query operator
+* 4108 -- Only one collection operation allowed
+* 4109 -- Only one cursor operation allowed
+* 4110 -- Cursor method can't run after collection method
 
 #### 5100 -- Internal error - DB
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Mongo errors are passed back directly. Additional error codes:
 * 4103 -- $where queries disabled
 * 4104 -- $mapReduce queries disabled
 * 4105 -- $aggregate queries disabled
+* 4106 -- $query property deprecated in queries
+* 4107 -- Unknown query operator
 
 #### 5100 -- Internal error - DB
 

--- a/index.js
+++ b/index.js
@@ -807,7 +807,9 @@ ShareDbMongo.prototype.skipPoll = function(collectionName, id, op, query) {
 
 function getFields(query) {
   var fields = {};
-  getInnerFields(query.$query, fields);
+  if (query.hasOwnProperty('$distinct')) {
+    fields[query.$distinct.split('.')[0]] = true;
+  }
   getInnerFields(query.$orderby, fields);
   getInnerFields(query.$sort, fields);
   getInnerFields(query, fields);

--- a/package.json
+++ b/package.json
@@ -5,14 +5,15 @@
   "main": "index.js",
   "dependencies": {
     "async": "^1.4.2",
-    "mongodb": "^2.0.45",
+    "mongodb": "^2.1.2",
     "sharedb": "^0.11.6"
   },
   "devDependencies": {
     "coveralls": "^2.11.8",
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "sharedb-mingo-memory": "^0.1.10"
   },
   "scripts": {
     "test": "node_modules/.bin/mocha",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",
     "mocha": "^2.3.3",
-    "sharedb-mingo-memory": "^0.1.10"
+    "sharedb-mingo-memory": "^0.1.11"
   },
   "scripts": {
     "test": "node_modules/.bin/mocha",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --reporter spec
 --check-leaks
 --globals Promise
---timeout 5000
+--timeout 10000

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --reporter spec
 --check-leaks
 --globals Promise
---timeout 10000
+--timeout 18000

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var expect = require('expect.js');
 var mongodb = require('mongodb');
 var ShareDbMongo = require('../index');
+var makeSortedQuery = require('sharedb-mingo-memory/make-sorted-query');
 
 var mongoUrl = process.env.TEST_MONGO_URL || 'mongodb://localhost:27017/test';
 
@@ -15,7 +16,7 @@ function create(callback) {
   });
 }
 
-require('sharedb/test/db')(create);
+require('sharedb/test/db')(create, makeSortedQuery);
 
 describe('mongo db', function() {
   beforeEach(function(done) {
@@ -87,7 +88,7 @@ describe('mongo db', function() {
       db.commit('testcollection', 'test1', {v: 0, create: {}}, snapshots[0], function(err) {
         db.commit('testcollection', 'test2', {v: 0, create: {}}, snapshots[1], function(err) {
           db.commit('testcollection', 'test3', {v: 0, create: {}}, snapshots[2], function(err) {
-            var query = {$distinct: true, $field: 'y', $query: {}};
+            var query = {$distinct: {field: 'y'}};
             db.query('testcollection', query, null, null, function(err, results, extra) {
               if (err) throw err;
               expect(extra).eql([1, 2]);
@@ -145,16 +146,16 @@ describe('mongo db', function() {
         db.commit('testcollection', 'test2', {v: 0, create: {}}, snapshots[1], function(err) {
           db.commit('testcollection', 'test3', {v: 0, create: {}}, snapshots[2], function(err) {
             var query = {
-              $mapReduce: true,
-              $map: function() {
-                emit(this.player, this.score);
-              },
-              $reduce: function(key, values) {
-                return values.reduce(function(t, s) {
-                  return t + s;
-                });
-              },
-              $query: {}
+              $mapReduce: {
+                map: function() {
+                  emit(this.player, this.score);
+                },
+                reduce: function(key, values) {
+                  return values.reduce(function(t, s) {
+                    return t + s;
+                  });
+                }
+              }
             };
             db.query('testcollection', query, null, null, function(err) {
               expect(err).ok();
@@ -177,16 +178,16 @@ describe('mongo db', function() {
         db.commit('testcollection', 'test2', {v: 0, create: {}}, snapshots[1], function(err) {
           db.commit('testcollection', 'test3', {v: 0, create: {}}, snapshots[2], function(err) {
             var query = {
-              $mapReduce: true,
-              $map: function() {
-                emit(this.player, this.score);
-              },
-              $reduce: function(key, values) {
-                return values.reduce(function(t, s) {
-                  return t + s;
-                });
-              },
-              $query: {}
+              $mapReduce: {
+                map: function() {
+                  emit(this.player, this.score);
+                },
+                reduce: function(key, values) {
+                  return values.reduce(function(t, s) {
+                    return t + s;
+                  });
+                }
+              }
             };
             db.query('testcollection', query, null, null, function(err, results, extra) {
               if (err) throw err;

--- a/test/test.js
+++ b/test/test.js
@@ -79,7 +79,7 @@ describe('mongo db', function() {
     });
 
     it('$query is deprecated', function(done) {
-      this.db.queryPollDoc('testcollection', 'somedoc', {$query: {}}, null, function(err) {
+      this.db.query('testcollection', {$query: {}}, null, null, function(err) {
         expect(err).ok();
         expect(err.code).eql(4106);
         done();
@@ -87,7 +87,7 @@ describe('mongo db', function() {
     });
 
     it('unknown query operator error', function(done) {
-      this.db.queryPollDoc('testcollection', 'somedoc', {$asdfasdf: {}}, null, function(err) {
+      this.db.query('testcollection', {$asdfasdf: {}}, null, null, function(err) {
         expect(err).ok();
         expect(err.code).eql(4107);
         done();
@@ -95,7 +95,7 @@ describe('mongo db', function() {
     });
 
     it('only one collection operation allowed', function(done) {
-      this.db.queryPollDoc('testcollection', 'somedoc', {$distinct: {y: 1}, $aggregate: {}}, null, function(err) {
+      this.db.query('testcollection', {$distinct: {y: 1}, $aggregate: {}}, null, null, function(err) {
         expect(err).ok();
         expect(err.code).eql(4108);
         done();
@@ -103,7 +103,7 @@ describe('mongo db', function() {
     });
 
     it('only one cursor operation allowed', function(done) {
-      this.db.queryPollDoc('testcollection', 'somedoc', {$count: true, $explain: true}, null, function(err) {
+      this.db.query('testcollection', {$count: true, $explain: true}, null, null, function(err) {
         expect(err).ok();
         expect(err.code).eql(4109);
         done();
@@ -111,17 +111,34 @@ describe('mongo db', function() {
     });
 
     it('cursor transform can\'t run after collection operation', function(done) {
-      this.db.queryPollDoc('testcollection', 'somedoc', {$distinct: {y: 1}, $sort: {y: 1}}, null, function(err) {
+      this.db.query('testcollection', {$distinct: {y: 1}, $sort: {y: 1}}, null, null, function(err) {
         expect(err).ok();
         expect(err.code).eql(4110);
         done();
       });
     });
 
-    it('cursor operation can\'t run after colletction operation', function(done) {
-      this.db.queryPollDoc('testcollection', 'somedoc', {$distinct: {y: 1}, $count: true}, null, function(err) {
+    it('cursor operation can\'t run after collection operation', function(done) {
+      this.db.query('testcollection', {$distinct: {y: 1}, $count: true}, null, null, function(err) {
         expect(err).ok();
         expect(err.code).eql(4110);
+        done();
+      });
+    });
+
+    it('non-object $readPref should return error', function(done) {
+      this.db.query('testcollection', {$readPref: true}, null, null, function(err) {
+        expect(err).ok();
+        expect(err.code).eql(4111);
+        done();
+      });
+    });
+
+    it('malformed $mapReduce', function(done) {
+      this.db.allowJSQueries = true; // required for $mapReduce
+      this.db.query('testcollection', {$mapReduce: true}, null, null, function(err) {
+        expect(err).ok();
+        expect(err.code).eql(4111);
         done();
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -78,6 +78,54 @@ describe('mongo db', function() {
       });
     });
 
+    it('$query is deprecated', function(done) {
+      this.db.queryPollDoc('testcollection', 'somedoc', {$query: {}}, null, function(err) {
+        expect(err).ok();
+        expect(err.code).eql(4106);
+        done();
+      });
+    });
+
+    it('unknown query operator error', function(done) {
+      this.db.queryPollDoc('testcollection', 'somedoc', {$asdfasdf: {}}, null, function(err) {
+        expect(err).ok();
+        expect(err.code).eql(4107);
+        done();
+      });
+    });
+
+    it('only one collection operation allowed', function(done) {
+      this.db.queryPollDoc('testcollection', 'somedoc', {$distinct: {y: 1}, $aggregate: {}}, null, function(err) {
+        expect(err).ok();
+        expect(err.code).eql(4108);
+        done();
+      });
+    });
+
+    it('only one cursor operation allowed', function(done) {
+      this.db.queryPollDoc('testcollection', 'somedoc', {$count: true, $explain: true}, null, function(err) {
+        expect(err).ok();
+        expect(err.code).eql(4109);
+        done();
+      });
+    });
+
+    it('cursor transform can\'t run after collection operation', function(done) {
+      this.db.queryPollDoc('testcollection', 'somedoc', {$distinct: {y: 1}, $sort: {y: 1}}, null, function(err) {
+        expect(err).ok();
+        expect(err.code).eql(4110);
+        done();
+      });
+    });
+
+    it('cursor operation can\'t run after colletction operation', function(done) {
+      this.db.queryPollDoc('testcollection', 'somedoc', {$distinct: {y: 1}, $count: true}, null, function(err) {
+        expect(err).ok();
+        expect(err.code).eql(4110);
+        done();
+      });
+    });
+
     it('$distinct should perform distinct operation', function(done) {
       var snapshots = [
         {type: 'json0', v: 1, data: {x: 1, y: 1}},


### PR DESCRIPTION
* Use `makeSortedQuery` from sharedb-mingo-memory in tests
* Deprecate the `{$query: ..., $count: ...}` style queries that no longer work in Mongo 3.2. The new query format is `{foo: bar, $count: ...}`. Properties that begin with $ are mapped to collection or cursor methods, where the value of the property maps to the argument to the method. (The exception is `$readPref` which maps an object into the two arguments passed into the `readPref` cursor method)
* Expand support to all collection and cursor operators supported by Mongo 3.2 and Node driver 2.1
* Replace normalizeQuery with parseQuery
* Backwards incompatible changes:
  * `{$mapReduce: true, $map: ..., $reduce: ..., $scope: ...}` is now `{$mapReduce: {map: ..., reduce: ..., scope: ...}}`
  * `{$distinct: true: $field: 'y'}` is now `{$distinct: {field: 'y'}}`