### PR TITLE
Deprecate ShareDb({mongo: (mongo connection})

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,9 +55,7 @@ function ShareDbMongo(mongo, options) {
     this.pendingConnect = [];
     this._connect(mongo, options);
   } else {
-    this.mongo = mongo;
-    this.mongoPoll = options.mongoPoll;
-    this.pendingConnect = null;
+    throw new Error('deprecated: pass mongo as url string or function with callback');
   }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -6,15 +6,17 @@ var getQuery = require('sharedb-mingo-memory/get-query');
 var mongoUrl = process.env.TEST_MONGO_URL || 'mongodb://localhost:27017/test';
 
 function create(callback) {
-  mongodb.connect(mongoUrl, function(err, mongo) {
-    if (err) throw err;
-    mongo.dropDatabase(function(err) {
+  var db = ShareDbMongo({mongo: function(shareDbCallback) {
+    mongodb.connect(mongoUrl, function(err, mongo) {
       if (err) throw err;
-      var db = ShareDbMongo({mongo: mongo});
-      callback(null, db, mongo);
+      mongo.dropDatabase(function(err) {
+        if (err) throw err;
+        shareDbCallback(null, mongo);
+        callback(null, db, mongo);
+      });
     });
-  });
-}
+  }});
+};
 
 require('sharedb/test/db')({create: create, getQuery: getQuery});
 


### PR DESCRIPTION
Instead, pass a callback into the 'mongo' property