### PR TITLE
Fix Markdown numbering issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,22 @@ There are two ways to instantiate a sharedb-mongo wrapper:
 1. The simplest way is to invoke the module and pass in your mongo DB
 arguments as arguments to the module function. For example:
 
-```javascript
-const db = require('sharedb-mongo')('mongodb://localhost:27017/test');
-const backend = new ShareDB({db});
-```
+    ```javascript
+    const db = require('sharedb-mongo')('mongodb://localhost:27017/test');
+    const backend = new ShareDB({db});
+    ```
 
 2. If you already have a function that creates a mongo connection that
 you want to use, you alternatively can pass it into sharedb-mongo:
 
-```javascript
-require('mongodb').connect('mongodb://localhost:27017/test', function(err, mongo) {
-  if (err) throw err;
-  var db = require('sharedb-mongo')({mongo: function(callback) {
-    // callback expects (err, db)
-  }});
-});
-```
+    ```javascript
+    require('mongodb').connect('mongodb://localhost:27017/test', function(err, mongo) {
+      if (err) throw err;
+      var db = require('sharedb-mongo')({mongo: function(callback) {
+        // callback expects (err, db)
+      }});
+    });
+    ```
 
 
 ## Queries


### PR DESCRIPTION
Previously, the numbered entries both started with 1 in the rendered README. After this change, the numbering is correct, and reads 1. then 2.