### PR TITLE
Fix broken mongodb link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ together with snapshots.
 
 ## Usage
 
-`sharedb-mongo` wraps native [mongodb](https://github.com/mongodb/node-
-mongodb-native), and it supports the same configuration options.
+`sharedb-mongo` wraps native [mongodb](https://github.com/mongodb/node-mongodb-native), and it supports the same configuration options.
 
 There are two ways to instantiate a sharedb-mongo wrapper:
 


### PR DESCRIPTION
The link to the node-mongodb-native package was broken, because its URL was interrupted with a newline in the Markdown.