### PR TITLE
Fix to work with the latest version of mongo driver

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,14 +163,14 @@ ShareDbMongo.prototype._connect = function(mongo, options) {
     mongoOptions = options.mongoOptions;
   } else {
     mongoOptions = Object.assign({}, options);
-    delete options.mongo;
-    delete options.pollDelay;
-    delete options.mongoPoll;
-    delete options.mongoPollOptions;
-    delete options.disableIndexCreation;
-    delete options.allowAllQueries;
-    delete options.allowJSQueries;
-    delete options.allowAggregateQueries;
+    delete mongoOptions.mongo;
+    delete mongoOptions.pollDelay;
+    delete mongoOptions.mongoPoll;
+    delete mongoOptions.mongoPollOptions;
+    delete mongoOptions.disableIndexCreation;
+    delete mongoOptions.allowAllQueries;
+    delete mongoOptions.allowJSQueries;
+    delete mongoOptions.allowAggregateQueries;
   }
   mongodb.connect(mongo, mongoOptions, finish);
 };

--- a/index.js
+++ b/index.js
@@ -155,7 +155,24 @@ ShareDbMongo.prototype._connect = function(mongo, options) {
     mongo(finish);
     return;
   }
-  mongodb.connect(mongo, options, finish);
+  // Get mongo options from the explicitly defined field `mongoOptions` or
+  // sanitize the whole options object by removing all ShareDB-specific options
+  // TODO: Deprecate the ability to pass mongo options implicitly
+  var mongoOptions;
+  if (options.mongoOptions) {
+    mongoOptions = options.mongoOptions;
+  } else {
+    mongoOptions = Object.assign({}, options);
+    delete options.mongo;
+    delete options.pollDelay;
+    delete options.mongoPoll;
+    delete options.mongoPollOptions;
+    delete options.disableIndexCreation;
+    delete options.allowAllQueries;
+    delete options.allowJSQueries;
+    delete options.allowAggregateQueries;
+  }
+  mongodb.connect(mongo, mongoOptions, finish);
 };
 
 ShareDbMongo.prototype.close = function(callback) {


### PR DESCRIPTION
The latest version of `mongodb` throws error on unknown options. In a simple ShareDB usecase (when  a separate `mongoPoll` database is not used) mongo gets its options from the mutual pool of options for mongo and for ShareDB. This leads to errors like `allowAllQueries options is not supported` in `mongodb`.

This pull request fixes this issue by adding sanitization of options (removes all sharedb-specific options) before passing them to mongo.

**Suggestion:** Passing mongo options implicitly should be deprecated. We should always get mongo options from `mongoOptions` field.