### PR TITLE
Improve performance of `getLinkedOps`

### DIFF
--- a/index.js
+++ b/index.js
@@ -534,10 +534,10 @@ function getLinkedOps(ops, to, link) {
     if (to == null || op.v < to) {
       delete op._id;
       delete op.o;
-      linkedOps.unshift(op);
+      linkedOps.push(op);
     }
   }
-  return linkedOps;
+  return linkedOps.reverse();
 }
 
 function getOpsQuery(id, from) {


### PR DESCRIPTION
Running `getOps` to fetch a large number of operations is not very
performant.

Anecdotally, performing this operation on a local development machine
with a document comprising of ~200,000 operations takes ~20s.

The largest slow-down appears to come from the `getLinkedOps` method,
and in particular the use of `Array.unshift`.

This change makes a very simple change that `push`es to the array
instead of `unshift`, and then `reverse`s it at the end.

The anecdotal operation time using this modified function is now ~2s,
which is an improvement of an order of magnitude.