### PR TITLE
Reduce test flakiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 language: node_js
 
 node_js:
-  - 7
-  - 6
-  - 4
-  - 0.10
+  - "6"
+  - "8"
+  - "10"
 
 services:
   - docker
 
 env:
-  - MONGODB_VERSION="2.4"
   - MONGODB_VERSION="2.6"
-  - MONGODB_VERSION="3.0"
-  - MONGODB_VERSION="3.2"
-  - MONGODB_VERSION="3.4"
+  - MONGODB_VERSION="3.6"
+  - MONGODB_VERSION="4.0"
 
 before_install:
   - docker run -d -p 127.0.0.1:27017:27017 mongo:$MONGODB_VERSION
@@ -22,8 +19,9 @@ before_install:
 before_script:
   - until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done
 
-# Run twice due to Mongo flakiness
-script: "npm run test-cover || npm run test-cover"
+script:
+  - npm run test-cover
 
 # Send coverage data to Coveralls
-after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+after_script:
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",
     "mocha": "^2.3.3",
-    "sharedb-mingo-memory": "^1.0.0-beta"
+    "sharedb-mingo-memory": "^1.0.1"
   },
   "scripts": {
     "test": "node_modules/.bin/mocha",


### PR DESCRIPTION
This change attempts to reduce build flakiness by:

  - updating the versions of Node and ShareDb we run Travis against
  - bumping the `sharedb-mingo-memory` version to a version which [fixes its unit tests][1]

[1]: https://github.com/share/sharedb-mingo-memory/pull/5