### PR TITLE
Always include `m` in snapshot

### DIFF
--- a/index.js
+++ b/index.js
@@ -1221,7 +1221,7 @@ function MongoSnapshot(id, version, type, data, meta, opLink) {
   this.v = version;
   this.type = type;
   this.data = data;
-  if (meta) this.m = meta;
+  this.m = meta == null ? null : meta;
   if (opLink) this._opLink = opLink;
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "expect.js": "^0.3.1",
     "istanbul": "^0.4.2",
     "mocha": "^2.3.3",
-    "sharedb-mingo-memory": "^1.0.1"
+    "sharedb-mingo-memory": "^1.0.2"
   },
   "scripts": {
     "test": "node_modules/.bin/mocha",

--- a/test/test_mongo.js
+++ b/test/test_mongo.js
@@ -353,7 +353,7 @@ describe('mongo db connection', function() {
     });
 
     it('commit and query', function(done) {
-      var snapshot = {type: 'json0', v: 1, data: {}, id: "test"};
+      var snapshot = {type: 'json0', v: 1, data: {}, id: "test", m: null};
       var db = this.db;
 
       db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, function(err) {


### PR DESCRIPTION
This change updates the `MongoSnapshot` class to always include the `m`
field, in line with the [recent change to the core `Snapshot` class][1]

[1]: https://github.com/share/sharedb/pull/220/files#diff-09a9af1416a54a5b125a5c2e1e6c2a30R7

## Dependencies

- [x] https://github.com/share/sharedb-mingo-memory/pull/6