### PR TITLE
Put getCommittedOpVersion onto ShareDbMongo.prototype instead of base DB.prototype.

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ ShareDbMongo.prototype.getOpsBulk = function(collectionName, fromMap, toMap, opt
   });
 };
 
-DB.prototype.getCommittedOpVersion = function(collectionName, id, snapshot, op, options, callback) {
+ShareDbMongo.prototype.getCommittedOpVersion = function(collectionName, id, snapshot, op, options, callback) {
   var self = this;
   this.getOpCollection(collectionName, function(err, opCollection) {
     if (err) return callback(err);


### PR DESCRIPTION
This should fix an issue that was reported in https://github.com/share/sharedb-mingo-memory/issues/8.

We hadn't seen it cause problems before because with just one adapter, e.g. just sharedb-mongo or just sharedb-mingo-memory, there wasn't a practical difference in behavior despite putting it on the wrong prototype.