### PR TITLE
$aggregate forward-compatibility with mongodb@3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1372,13 +1372,15 @@ var collectionOperationsMap = {
       if (Array.isArray(resultsOrCursor)) {
         // 2.x Mongo driver directly produces a results array:
         // https://mongodb.github.io/node-mongodb-native/2.2/api/Collection.html#aggregate
-        cb(null, resultsOrCursor);
+        var resultsArray = resultsOrCursor;
+        cb(null, resultsArray);
       } else {
         // 3.x Mongo driver produces an AggregationCursor:
         // https://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#aggregate
         //
         // ShareDB expects serializable result data, so use `Cursor#toArray` for that.
-        resultsOrCursor.toArray(cb);
+        var cursor = resultsOrCursor;
+        cursor.toArray(cb);
       }
     });
   },


### PR DESCRIPTION
This covers part of the work for https://github.com/share/sharedb-mongo/issues/76 - specifically, making `$aggregate` forwards-compatible with mongodb@3, if a pre-created 3.x DB client is passed into sharedb-mongo via a provider function.

`mongodb.Collection#aggregate` results in a result array in 2.x, and it results in a `mongodb.AggregationCursor` in 3.x, so check the result type and unpack it from the cursor if needed.