### PR TITLE
Ignore `package-lock.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.DS_Store
 node_modules
 coverage
+package-lock.json
 
 # IDEs
 .vscode


### PR DESCRIPTION
As a general rule-of-thumb, a `package-lock.json` is only useful in an
application (rather than a library), because:

> One key detail about `package-lock.json` is that it cannot be
> published, and it will be ignored if found in any place other than the
> toplevel package.

https://docs.npmjs.com/files/package-lock.json

This change adds `package-lock.json` to our `.gitignore`.