### PR TITLE
Fix unnecessary `_type: {$type: 2}` added to some $or queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -1194,7 +1194,6 @@ function deletedDocCouldSatisfyQuery(query) {
           return false;
         }
       }
-      return true;
     } else {
       // Malformed? Play it safe.
       return true;

--- a/index.js
+++ b/index.js
@@ -1201,20 +1201,6 @@ function deletedDocCouldSatisfyQuery(query) {
     }
   }
 
-  if (query.hasOwnProperty('$or')) {
-    if (Array.isArray(query.$or)) {
-      for (var i = 0; i < query.$or.length; i++) {
-        if (deletedDocCouldSatisfyQuery(query.$or[i])) {
-          return true;
-        }
-      }
-      return false;
-    } else {
-      // Malformed? Play it safe.
-      return true;
-    }
-  }
-
   for (var prop in query) {
     // Ignore fields that remain set on deleted docs
     if (
@@ -1229,6 +1215,10 @@ function deletedDocCouldSatisfyQuery(query) {
     ) {
       continue;
     }
+    // Top-level operators with special handling in this function
+    if (prop === '$and' || prop === '$or') {
+      continue;
+    }
     // When using top-level operators that we don't understand, play
     // it safe
     if (prop[0] === '$') {
@@ -1236,6 +1226,20 @@ function deletedDocCouldSatisfyQuery(query) {
     }
     if (!couldMatchNull(query[prop])) {
       return false;
+    }
+  }
+
+  if (query.hasOwnProperty('$or')) {
+    if (Array.isArray(query.$or)) {
+      for (var i = 0; i < query.$or.length; i++) {
+        if (deletedDocCouldSatisfyQuery(query.$or[i])) {
+          return true;
+        }
+      }
+      return false;
+    } else {
+      // Malformed? Play it safe.
+      return true;
     }
   }
 

--- a/test/test_mongo.js
+++ b/test/test_mongo.js
@@ -481,10 +481,18 @@ describe('parse query', function() {
       doesNotModify({foo: {$in: [null, 2, 3]}, bar: 1});
     });
 
-    it('top-level $and', function() {
+    it('top-level $and alone', function() {
       doesNotModify({$and: [{foo: {$ne: null}}, {bar: {$ne: null}}]});
       doesNotModify({$and: [{foo: {$ne: 1}}, {bar: {$ne: null}}]});
       addsType({$and: [{foo: {$ne: 1}}, {bar: {$ne: 1}}]});
+    });
+
+    describe('top-level $and with other conditions', function() {
+      // If the top-level $and could match a deleted doc, it should continue looking at the other
+      // top-level conditions.
+      it('does not add _type for "field: nonNullValue"', function() {
+        doesNotModify({$and: [{foo: {$ne: true}}], bar: 1});
+      });
     });
 
     it('top-level $or alone', function() {

--- a/test/test_mongo.js
+++ b/test/test_mongo.js
@@ -528,6 +528,8 @@ describe('parse query', function() {
       addsType({foo: {$bad: 1}});
       addsType({$bad: [2, 3]});
       addsType({$and: [[{foo: 1}]]});
+      addsType({$and: 1});
+      addsType({$expr: {$gt: {$subtract: ['$endDate', '$startDate']}}});
     });
   });
 });


### PR DESCRIPTION
sharedb-mongo will add a `_type: {$type: 2}` to queries where the query conditions don't already filter out deleted docs.
- 2 is the [BSON type number](https://docs.mongodb.com/manual/reference/bson-types/) for string.
- `_type` contains the OT type, e.g. "http://sharejs.org/types/JSONv0", and it will be a string for non-deleted ShareDB docs and `null` for deleted ShareDB docs.

There was a bug where the `_type` condition was being unnecessarily added for queries that had both a top-level `$or` and other conditions that guarantee the query as a whole will not match deleted docs.

An artificial example - Here, the `bar: 1` guarantees that the query won't match deleted docs, but the code had still been adding `_type: {$type: 2}` to the query.

```js
{
  $or: [ { foo: { $ne: true } } ],
  bar: 1
}
```

The bug was because the code to handle `$or` was exiting early, before the checks on non-$ conditions. The fix was to move the `$or` handling to the end.