### PR TITLE
Upgrade to async@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MongoDB database adapter for ShareDB",
   "main": "index.js",
   "dependencies": {
-    "async": "^1.5.2",
+    "async": "^2.6.3",
     "mongodb": "^2.1.2 || ^3.0.0",
     "sharedb": "^1.0.0-beta"
   },


### PR DESCRIPTION
The only usage of async here is an `async.parallel` with 2 tasks, which isn't affected by the [breaking changes in async@2](https://github.com/caolan/async/blob/master/CHANGELOG.md#v200):
https://github.com/share/sharedb-mongo/blob/693ddd18344fe11a4adc06ef8dfeb3ad352d9726/index.js#L148-L156

We can't upgrade to async@3 because it uses ES6 features like arrow functions, and ShareDB currently targets ES5 without needing to transpile. async@2 is still actively receiving patch updates.