### PR TITLE
Add callback error handling in queryPollDoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -829,6 +829,7 @@ ShareDbMongo.prototype.queryPoll = function(collectionName, inputQuery, options,
 ShareDbMongo.prototype.queryPollDoc = function(collectionName, id, inputQuery, options, callback) {
   var self = this;
   self.getCollectionPoll(collectionName, function(err, collection) {
+    if (err) return callback(err);
     var parsed = self._getSafeParsedQuery(inputQuery, callback);
     if (!parsed) return;
 


### PR DESCRIPTION
In `queryPollDoc()`, the callback for `getCollectionPoll()` does not have any error handling

Thus, when `collection` is undefined and an error is returned, we hit a TypeError when we try to call `find()` on `collection`

https://github.com/share/sharedb-mongo/blob/595f092f53e2dc13c4c45f5dd89c66921e77bfbc/index.js#L865-L867