### PR TITLE
Silence logger in tests

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,3 +2,4 @@
 --check-leaks
 --globals Promise
 --timeout 18000
+--file test/setup.js

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,10 @@
+var logger = require('sharedb/lib/logger');
+
+if (process.env.LOGGING !== 'true') {
+  // Silence the logger for tests by setting all its methods to no-ops
+  logger.setMethods({
+    info: function() {},
+    warn: function() {},
+    error: function() {}
+  });
+}


### PR DESCRIPTION
This change reads across the config from `sharedb` to silence the logger
in tests to reduce noise when running the test suite.