### PR TITLE
Add `ot-json1` as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-config-google": "^0.13.0",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
+    "ot-json1": "^1.0.1",
     "sharedb-mingo-memory": "^1.1.1",
     "sinon": "^6.1.5"
   },


### PR DESCRIPTION
Some of the new `sharedb` tests rely on `ot-json1` as a dependency.
Without it, the tests fail to run.

This change adds `ot-json1` as a `devDependency`. Note that we didn't
need to do this for `ot-json0`, because `sharedb` ships with that as a
`dependency`.