### PR TITLE
Greenify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-config-google": "^0.13.0",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
+    "ot-json1": "^1.0.1",
     "sharedb-mingo-memory": "^1.1.1",
     "sinon": "^6.1.5"
   },


### PR DESCRIPTION
This change combines two commits that aim to greenify the build due to upstream library changes. This should also greenify the _downstream_ `sharedb` build.

## Remove `sharedb-mingo-memory` tests

This change reverts https://github.com/share/sharedb-mongo/commit/38d6f8a7130389208633007a92aa57c7a53e6e14

That change moved some tests from this library into
`sharedb-mingo-memory` and then ran them in this library by requiring
them from that one.

While this de-duplicates code, it also introduces a surprising coupling
between the tests of the two libraries. `sharedb-mingo-memory` can
add arbitrary tests to the imported suite, which may not necessarily
be applicable to `sharedb-mongo`, and even fail the `sharedb-mongo`
build, as is happening now.

This change removes that `require`, and just puts the original tests
back (ignoring any other tests that have been added to that external
suite since).

## Add `ot-json1` as a `devDependency`

Some of the new `sharedb` tests rely on `ot-json1` as a dependency.
Without it, the tests fail to run.

This change adds `ot-json1` as a `devDependency`. Note that we didn't
need to do this for `ot-json0`, because `sharedb` ships with that as a
`dependency`.