### PR TITLE
Fix a $mapReduce test to be order insensitive

### DIFF
--- a/test/test_mongo.js
+++ b/test/test_mongo.js
@@ -362,7 +362,7 @@ describe('mongo db', function() {
             };
             db.query('testcollection', query, null, null, function(err, results, extra) {
               if (err) return done(err);
-              expect(extra).eql([{_id: 'a', value: 12}, {_id: 'b', value: 15}]);
+              expect(extra).to.have.deep.members([{_id: 'a', value: 12}, {_id: 'b', value: 15}]);
               done();
             });
           });


### PR DESCRIPTION
Mongo server 4.4 changed something internally that breaks the ordering of one of the `$mapReduce` tests' results. The results aren't guaranteed to be in a certain order anyways, so update the test to use an order-insensitive assertion.

Fixes https://github.com/share/sharedb-mongo/issues/95