### PR TITLE
Early return `close()` if already closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,8 @@ ShareDbMongo.prototype.close = function(callback) {
   }
   var self = this;
   this.getDbs(function(err) {
+    // Ignore "already closed"
+    if (err && err.code === 5101) return callback();
     if (err) return callback(err);
     self.closed = true;
     self._mongoClient.close(function(err) {


### PR DESCRIPTION
Fixes https://github.com/share/sharedb-mongo/issues/99 (hopefully)

It can be surprising to call `db.close()` multiple times and get an
error because we've already closed.

This change swallows the already closed error if caught in `db.close()`.

Note that a test will be added for this upstream in `sharedb`:
https://github.com/share/sharedb/pull/412