### PR TITLE
Trigger a `beforeCreate` middleware before inserting a new document

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Register a new middleware.
 
 - `action` _(String)_
   One of:
+  - `'beforeCreate'`: directly before the call to write a new document
   - `'beforeOverwrite'`: directly before the call to replace a document, can include edits as well as deletions
   - `'beforeSnapshotLookup'`: directly before the call to issue a query for one or more snapshots by ID
 - `fn` _(Function(context, callback))_
@@ -209,6 +210,9 @@ Register a new middleware.
     - `action`: The action this middleware is handling
     - `collectionName`: The collection name being handled
     - `options`: Original options as they were passed into the relevant function that triggered the action
+    - `'beforeCreate'` actions have additional context properties:
+      - `documentToWrite` - The document to be written
+      - `op` - The op that represents the changes that will be made to the document
     - `'beforeOverwrite'` actions have additional context properties:
       - `documentToWrite` - The document to be written
       - `op` - The op that represents the changes that will be made to the document

--- a/src/middleware/actions.js
+++ b/src/middleware/actions.js
@@ -1,4 +1,6 @@
 module.exports = {
+  // Triggers before the call to write a new document is made
+  beforeCreate: 'beforeCreate',
   // Triggers before the call to replace a document is made
   beforeOverwrite: 'beforeOverwrite',
   // Triggers directly before the call to issue a query for snapshots

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -207,6 +207,7 @@ describe('mongo db middleware', function() {
       db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, function(err) {
         expectDocumentNotToExist(function() {
           if (err) return done();
+          done('Expected an error, did not get one');
         });
       });
     });
@@ -346,7 +347,7 @@ describe('mongo db middleware', function() {
     var query = {_id: 'test1'};
 
     db.query('testcollection', query, null, null, function(err, results) {
-      if (err) return done(err);
+      if (err) return cb(err);
       expect(results).to.be.empty;
       cb();
     });


### PR DESCRIPTION
This middleware is similar to the `beforeOverwrite`, but it does not have a `query` since it is a brand new document