### PR TITLE
👷 Update build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,10 @@ jobs:
     strategy:
       matrix:
         node:
-        - 10
         - 12
         - 14
+        - 16
         mongodb:
-        - 3.6
         - 4.0
         - 4.2
         - 4.4


### PR DESCRIPTION
**BREAKING**: Drop Node v10 support
**BREAKING**: Drop MongoDB v3.6 support

This change runs the build against Node.js v16, which was
[released in April][1]. We stop testing against v10, which has now been
end-of-lifed.

We also stop testing against MongoDB v3.6, which has also been
[end-of-lifed][2].

[1]: https://nodejs.org/en/about/releases/
[2]: https://www.mongodb.com/support-policy