### PR TITLE
✅ Run tests against both `mongodb` drivers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var async = require('async');
-var mongodb = require('mongodb');
+var mongodb = require('./mongodb');
 var DB = require('sharedb').DB;
 var OpLinkValidator = require('./op-link-validator');
 var MiddlewareHandler = require('./src/middleware/middlewareHandler');

--- a/mongodb.js
+++ b/mongodb.js
@@ -1,0 +1,3 @@
+var version = process.env._SHAREDB_MONGODB_DRIVER || 'mongodb';
+var mongodb = require(version);
+module.exports = mongodb;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "eslint": "^5.16.0",
     "eslint-config-google": "^0.13.0",
     "mocha": "^6.2.2",
+    "mongodb2": "npm:mongodb@^2.1.2",
+    "mongodb3": "npm:mongodb@^3.0.0",
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
     "sharedb-mingo-memory": "^1.1.1",
@@ -23,7 +25,10 @@
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore '**/*.js'",
     "lint:fix": "npm run lint -- --fix",
     "test": "mocha",
-    "test-cover": "nyc --temp-dir=coverage -r text -r lcov npm test"
+    "test:mongodb2": "_SHAREDB_MONGODB_DRIVER=mongodb2 npm test",
+    "test:mongodb3": "_SHAREDB_MONGODB_DRIVER=mongodb3 npm test",
+    "test:all": "npm run test:mongodb2 && npm run test:mongodb3",
+    "test-cover": "nyc --temp-dir=coverage -r text -r lcov npm run test:all"
   },
   "repository": "git://github.com/share/sharedb-mongo.git",
   "author": "Nate Smith and Joseph Gentle",

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -173,14 +173,11 @@ describe('mongo db middleware', function() {
         expect(request.op).to.exist;
         expect(request.options.testOptions).to.equal('baz');
         next();
-        done();
       });
 
       var snapshot = {type: 'json0', id: 'test1', v: 1, data: {foo: 'bar'}};
 
-      db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, {testOptions: 'baz'}, function(err) {
-        if (err) return done(err);
-      });
+      db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, {testOptions: 'baz'}, done);
     });
 
     it('should augment the written document when commit is called', function(done) {


### PR DESCRIPTION
We support both `mongodb` v2 and v3 drivers, but currently only run our
tests against one version.

This change runs our test suite against both versions of the driver,
and fixes a test that breaks in v2.