### PR TITLE
⬆️ Add support for `mongodb` v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "async": "^2.6.3",
-    "mongodb": "^2.1.2 || ^3.0.0",
+    "mongodb": "^2.1.2 || ^3.0.0 || ^4.0.0",
     "sharedb": "^1.0.0-beta"
   },
   "devDependencies": {
@@ -16,6 +16,7 @@
     "mocha": "^6.2.2",
     "mongodb2": "npm:mongodb@^2.1.2",
     "mongodb3": "npm:mongodb@^3.0.0",
+    "mongodb4": "npm:mongodb@^4.0.0",
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
     "sharedb-mingo-memory": "^1.1.1",
@@ -27,7 +28,8 @@
     "test": "mocha",
     "test:mongodb2": "_SHAREDB_MONGODB_DRIVER=mongodb2 npm test",
     "test:mongodb3": "_SHAREDB_MONGODB_DRIVER=mongodb3 npm test",
-    "test:all": "npm run test:mongodb2 && npm run test:mongodb3",
+    "test:mongodb4": "_SHAREDB_MONGODB_DRIVER=mongodb4 npm test",
+    "test:all": "npm run test:mongodb2 && npm run test:mongodb3 && npm run test:mongodb4",
     "test-cover": "nyc --temp-dir=coverage -r text -r lcov npm run test:all"
   },
   "repository": "git://github.com/share/sharedb-mongo.git",


### PR DESCRIPTION
This change adds support for [`mongodb` v4][1]. The only [changes][2]
that seem to affect us are:

 - removal of the top-level `connect()` function
 - removal of callbacks from `MongoClient.aggregate()`
 - disallowing of non-Mongo options being passed in the options object
   when connecting

## Dependencies

- [x] https://github.com/share/sharedb-mongo/pull/118

[1]: https://github.com/mongodb/node-mongodb-native/releases/tag/v4.0.0
[2]: https://github.com/mongodb/node-mongodb-native/blob/4.0/docs/CHANGES_4.0.0.md