### PR TITLE
Pass triggeredBy = 'submitRequest' to BeforeSnapshotLookup Middleware When Lookup is For Op Submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Register a new middleware.
       - `query` - A filter that will be used to lookup the document that is about to be edited, which should always include an ID and snapshot version e.g. `{_id: 'uuid', _v: 1}`
     - `'beforeSnapshotLookup'` actions have additional context properties:
       - `query` - A filter that will be used to lookup the snapshot. When a single snapshot is looked up the query will take the shape `{_id: docId}` while a bulk lookup by a list of IDs will resemble `{_id: {$in: docIdsArray}}`.
+      - `findOptions` - Middleware can define and populate this object on the context to pass options to the MongoDB driver when doing the lookup.
 
 ### Limitations
 

--- a/index.js
+++ b/index.js
@@ -254,23 +254,19 @@ ShareDbMongo.prototype.commit = function(collectionName, id, op, snapshot, optio
 };
 
 function createRequestForMiddleware(options, collectionName, op, fields) {
-  // When we're creating a request for submitting an op, let downstream middleware know.
-  if (fields && fields.$submit === true) {
-    if (!options) {
-      options = {};
-    }
-    /**
-     * TODO What if sharedb populated this?
-     *  It looks like we would have the following values for 'trigger': submitRequest, queryEmit, fetch
-     */
-    options.triggeredBy = 'submitRequest';
-  }
   // Create a new request object which will be passed to helper functions and middleware
   var request = {
     options: options,
     collectionName: collectionName
   };
   if (op) request.op = op;
+  // When we're creating a request for submitting an op, let downstream middleware know.
+  if (fields && fields.$submit === true) {
+    /**
+     * TODO What if sharedb populated this? We could use MIDDLEWARE_ACTIONS.
+     */
+    request.triggeredBy = 'submitRequest';
+  }
   return request;
 }
 

--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ ShareDbMongo.prototype.close = function(callback) {
 
 ShareDbMongo.prototype.commit = function(collectionName, id, op, snapshot, options, callback) {
   var self = this;
-  var request = createRequestForMiddleware(null, options, collectionName, op);
+  var request = createRequestForMiddleware(options, collectionName, op);
   this._writeOp(collectionName, id, op, snapshot, function(err, result) {
     if (err) return callback(err);
     var opId = result.insertedId;
@@ -343,7 +343,7 @@ ShareDbMongo.prototype.getSnapshot = function(collectionName, id, fields, option
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);
 
-      collection.find(request.query, request.queryOptions).limit(1).project(projection).next(function(err, doc) {
+      collection.find(request.query, request.findOptions).limit(1).project(projection).next(function(err, doc) {
         if (err) return callback(err);
         var snapshot = (doc) ? castToSnapshot(doc) : new MongoSnapshot(id, 0, null, undefined);
         callback(null, snapshot);
@@ -363,7 +363,7 @@ ShareDbMongo.prototype.getSnapshotBulk = function(collectionName, ids, fields, o
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);
 
-      collection.find(request.query, request.queryOptions).project(projection).toArray(function(err, docs) {
+      collection.find(request.query, request.findOptions).project(projection).toArray(function(err, docs) {
         if (err) return callback(err);
         var snapshotMap = {};
         for (var i = 0; i < docs.length; i++) {

--- a/index.js
+++ b/index.js
@@ -799,7 +799,7 @@ ShareDbMongo.prototype._getSnapshotOpLink = function(collectionName, id, options
     request.query = query;
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);
-      collection.find(query).limit(1).project(projection).next(callback);
+      collection.find(query, request.findOptions).limit(1).project(projection).next(callback);
     });
   });
 };
@@ -815,7 +815,7 @@ ShareDbMongo.prototype._getSnapshotOpLinkBulk = function(collectionName, ids, op
     request.query = query;
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);
-      collection.find(query).project(projection).toArray(callback);
+      collection.find(query, request.findOptions).project(projection).toArray(callback);
     });
   });
 };

--- a/index.js
+++ b/index.js
@@ -263,7 +263,7 @@ function createRequestForMiddleware(options, collectionName, op, fields) {
      * TODO What if sharedb populated this?
      *  It looks like we would have the following values for 'trigger': submitRequest, queryEmit, fetch
      */
-    options.trigger = 'submitRequest';
+    options.triggeredBy = 'submitRequest';
   }
   // Create a new request object which will be passed to helper functions and middleware
   var request = {

--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ function createRequestForMiddleware(fields, options, collectionName, op) {
     if (!options) {
       options = {};
     }
-    options.forSubmit = true;
+    options.isForSubmit = true;
   }
   // Create a new request object which will be passed to helper functions and middleware
   var request = {

--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ ShareDbMongo.prototype.commit = function(collectionName, id, op, snapshot, optio
   });
 };
 
-function createRequestForMiddleware(fields, options, collectionName, op) {
+function createRequestForMiddleware(options, collectionName, op, fields) {
   // When we're creating a request for submitting an op, let downstream middleware know.
   if (fields && fields.$submit === true) {
     if (!options) {
@@ -338,7 +338,7 @@ ShareDbMongo.prototype.getSnapshot = function(collectionName, id, fields, option
     if (err) return callback(err);
     var query = {_id: id};
     var projection = getProjection(fields, options);
-    var request = createRequestForMiddleware(fields, options, collectionName);
+    var request = createRequestForMiddleware(options, collectionName, null, fields);
     request.query = query;
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);
@@ -358,7 +358,7 @@ ShareDbMongo.prototype.getSnapshotBulk = function(collectionName, ids, fields, o
     if (err) return callback(err);
     var query = {_id: {$in: ids}};
     var projection = getProjection(fields, options);
-    var request = createRequestForMiddleware(fields, options, collectionName);
+    var request = createRequestForMiddleware(options, collectionName, null, fields);
     request.query = query;
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);
@@ -791,7 +791,7 @@ ShareDbMongo.prototype._getSnapshotOpLink = function(collectionName, id, options
     var query = {_id: id};
     var projection = {_id: 0, _o: 1, _v: 1};
 
-    var request = createRequestForMiddleware(null, options, collectionName);
+    var request = createRequestForMiddleware(options, collectionName);
     request.query = query;
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);
@@ -807,7 +807,7 @@ ShareDbMongo.prototype._getSnapshotOpLinkBulk = function(collectionName, ids, op
     var query = {_id: {$in: ids}};
     var projection = {_o: 1, _v: 1};
 
-    var request = createRequestForMiddleware(null, options, collectionName);
+    var request = createRequestForMiddleware(options, collectionName);
     request.query = query;
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);

--- a/index.js
+++ b/index.js
@@ -791,7 +791,7 @@ ShareDbMongo.prototype._getSnapshotOpLink = function(collectionName, id, options
     var query = {_id: id};
     var projection = {_id: 0, _o: 1, _v: 1};
 
-    var request = createRequestForMiddleware(options, collectionName);
+    var request = createRequestForMiddleware(null, options, collectionName);
     request.query = query;
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);
@@ -807,7 +807,7 @@ ShareDbMongo.prototype._getSnapshotOpLinkBulk = function(collectionName, ids, op
     var query = {_id: {$in: ids}};
     var projection = {_o: 1, _v: 1};
 
-    var request = createRequestForMiddleware(options, collectionName);
+    var request = createRequestForMiddleware(null, options, collectionName);
     request.query = query;
     self._middleware.trigger(MiddlewareHandler.Actions.beforeSnapshotLookup, request, function(middlewareErr) {
       if (middlewareErr) return callback(middlewareErr);

--- a/index.js
+++ b/index.js
@@ -259,7 +259,11 @@ function createRequestForMiddleware(options, collectionName, op, fields) {
     if (!options) {
       options = {};
     }
-    options.isForSubmit = true;
+    /**
+     * TODO What if sharedb populated this?
+     *  It looks like we would have the following values for 'trigger': submitRequest, queryEmit, fetch
+     */
+    options.trigger = 'submitRequest';
   }
   // Create a new request object which will be passed to helper functions and middleware
   var request = {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^2.6.3",
     "mongodb": "^2.1.2 || ^3.0.0",
-    "sharedb": "^1.0.0-beta"
+    "sharedb": "^1.9.1-beta"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
     "sharedb-mingo-memory": "^1.1.1",
-    "sinon": "^6.1.5"
+    "sinon": "^6.1.5",
+    "sinon-chai": "^3.7.0"
   },
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore '**/*.js'",

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -22,9 +22,11 @@ function create(callback) {
 }
 
 describe('mongo db middleware', function() {
+  var sandbox = sinon.createSandbox();
   var db;
 
   beforeEach(function(done) {
+    sandbox.spy(Collection.prototype, 'find');
     create(function(err, createdDb) {
       if (err) return done(err);
       db = createdDb;
@@ -33,6 +35,7 @@ describe('mongo db middleware', function() {
   });
 
   afterEach(function(done) {
+    sandbox.restore();
     db.close(done);
   });
 
@@ -241,7 +244,6 @@ describe('mongo db middleware', function() {
     });
 
     it('passes triggeredBy = submitRequest in options when fields has $submit = true', function(done) {
-      sinon.spy(Collection.prototype, 'find');
       var middlewareSpy = sinon.spy(function(request, next) {
         expect(request).to.have.all.keys([
           'action',
@@ -276,7 +278,6 @@ describe('mongo db middleware', function() {
           }, {
             maxTimeMS: 999
           })).to.equal(true);
-          Collection.prototype.find.restore(); // remove spy
           done();
         });
       });

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -245,18 +245,19 @@ describe('mongo db middleware', function() {
       });
     });
 
-    it('passes triggeredBy = submitRequest in options when fields has $submit = true', function(done) {
+    it('passes triggeredBy = submitRequest when fields has $submit = true', function(done) {
       var middlewareSpy = sinon.spy(function(request, next) {
         expect(request).to.have.all.keys([
           'action',
           'collectionName',
           'options',
-          'query'
+          'query',
+          'triggeredBy'
         ]);
         expect(request.action).to.equal(BEFORE_SNAPSHOT_LOOKUP);
         expect(request.collectionName).to.equal('testcollection');
         expect(request.options.testOptions).to.equal('yes');
-        expect(request.options.triggeredBy).to.equal('submitRequest');
+        expect(request.triggeredBy).to.equal('submitRequest');
         expect(request.query._id).to.equal('test1');
         // test that when we set findOptions in the middleware, they get passed to the Mongo driver.
         request.findOptions = {

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -254,9 +254,9 @@ describe('mongo db middleware', function() {
         expect(request.options.testOptions).to.equal('yes');
         expect(request.options.isForSubmit).to.equal(true);
         expect(request.query._id).to.equal('test1');
-        // test that when we set queryOptions in the middleware, they get passed to the Mongo driver.
-        request.queryOptions = {
-          isForSubmit: true
+        // test that when we set findOptions in the middleware, they get passed to the Mongo driver.
+        request.findOptions = {
+          maxTimeMS: 999
         };
         next();
       });
@@ -274,7 +274,7 @@ describe('mongo db middleware', function() {
           expect(Collection.prototype.find.calledOnceWith({
             _id: snapshot.id
           }, {
-            isForSubmit: true
+            maxTimeMS: 999
           })).to.equal(true);
           Collection.prototype.find.restore(); // remove spy
           done();

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -1,6 +1,8 @@
 var async = require('async');
 var sinon = require('sinon');
-var expect = require('chai').expect;
+var chai = require('chai');
+chai.use(require('sinon-chai'));
+var expect = chai.expect;
 var ShareDbMongo = require('..');
 var mongodb = require('./../mongodb');
 var Collection = mongodb.Collection;
@@ -272,12 +274,12 @@ describe('mongo db middleware', function() {
         }, {testOptions: 'yes'}, function(err, doc) {
           if (err) return done(err);
           expect(doc).to.exist;
-          expect(middlewareSpy.calledOnceWith(sinon.match.object, sinon.match.func)).to.equal(true);
-          expect(Collection.prototype.find.calledOnceWith({
+          expect(middlewareSpy).to.have.been.calledOnceWith(sinon.match.object, sinon.match.func);
+          expect(Collection.prototype.find).to.have.been.calledOnceWith({
             _id: snapshot.id
           }, {
             maxTimeMS: 999
-          })).to.equal(true);
+          });
           done();
         });
       });

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -271,7 +271,9 @@ describe('mongo db middleware', function() {
           if (err) return done(err);
           expect(doc).to.exist;
           expect(middlewareSpy.calledOnceWith(sinon.match.object, sinon.match.func)).to.equal(true);
-          expect(Collection.prototype.find.calledOnceWith(sinon.match.object, {
+          expect(Collection.prototype.find.calledOnceWith({
+            _id: snapshot.id
+          }, {
             forSubmit: true
           })).to.equal(true);
           Collection.prototype.find.restore(); // remove spy

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -240,7 +240,7 @@ describe('mongo db middleware', function() {
       });
     });
 
-    it('passes trigger = submitRequest in options when fields has $submit = true', function(done) {
+    it('passes triggeredBy = submitRequest in options when fields has $submit = true', function(done) {
       sinon.spy(Collection.prototype, 'find');
       var middlewareSpy = sinon.spy(function(request, next) {
         expect(request).to.have.all.keys([
@@ -252,7 +252,7 @@ describe('mongo db middleware', function() {
         expect(request.action).to.equal(BEFORE_SNAPSHOT_LOOKUP);
         expect(request.collectionName).to.equal('testcollection');
         expect(request.options.testOptions).to.equal('yes');
-        expect(request.options.trigger).to.equal('submitRequest');
+        expect(request.options.triggeredBy).to.equal('submitRequest');
         expect(request.query._id).to.equal('test1');
         // test that when we set findOptions in the middleware, they get passed to the Mongo driver.
         request.findOptions = {

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -240,7 +240,7 @@ describe('mongo db middleware', function() {
       });
     });
 
-    it('passes isForSubmit = true in options when fields has $submit = true', function(done) {
+    it('passes trigger = submitRequest in options when fields has $submit = true', function(done) {
       sinon.spy(Collection.prototype, 'find');
       var middlewareSpy = sinon.spy(function(request, next) {
         expect(request).to.have.all.keys([
@@ -252,7 +252,7 @@ describe('mongo db middleware', function() {
         expect(request.action).to.equal(BEFORE_SNAPSHOT_LOOKUP);
         expect(request.collectionName).to.equal('testcollection');
         expect(request.options.testOptions).to.equal('yes');
-        expect(request.options.isForSubmit).to.equal(true);
+        expect(request.options.trigger).to.equal('submitRequest');
         expect(request.query._id).to.equal('test1');
         // test that when we set findOptions in the middleware, they get passed to the Mongo driver.
         request.findOptions = {

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -240,7 +240,7 @@ describe('mongo db middleware', function() {
       });
     });
 
-    it('passes forSubmit = true in options when fields has $submit = true', function(done) {
+    it('passes isForSubmit = true in options when fields has $submit = true', function(done) {
       sinon.spy(Collection.prototype, 'find');
       var middlewareSpy = sinon.spy(function(request, next) {
         expect(request).to.have.all.keys([
@@ -252,11 +252,11 @@ describe('mongo db middleware', function() {
         expect(request.action).to.equal(BEFORE_SNAPSHOT_LOOKUP);
         expect(request.collectionName).to.equal('testcollection');
         expect(request.options.testOptions).to.equal('yes');
-        expect(request.options.forSubmit).to.equal(true);
+        expect(request.options.isForSubmit).to.equal(true);
         expect(request.query._id).to.equal('test1');
         // test that when we set queryOptions in the middleware, they get passed to the Mongo driver.
         request.queryOptions = {
-          forSubmit: true
+          isForSubmit: true
         };
         next();
       });
@@ -274,7 +274,7 @@ describe('mongo db middleware', function() {
           expect(Collection.prototype.find.calledOnceWith({
             _id: snapshot.id
           }, {
-            forSubmit: true
+            isForSubmit: true
           })).to.equal(true);
           Collection.prototype.find.restore(); // remove spy
           done();

--- a/test/test_mongo_middleware.js
+++ b/test/test_mongo_middleware.js
@@ -311,7 +311,7 @@ describe('mongo db middleware', function() {
             If we call done() in the middleware, we'll close the db connection, and then getOps will call _getOps()
             which will throw a "db connection closed" error.
            */
-          expect(middlewareSpy.calledOnceWith(sinon.match.object, sinon.match.func)).to.equal(true);
+          expect(middlewareSpy).to.have.been.calledOnceWith(sinon.match.object, sinon.match.func);
           done();
         });
       });
@@ -347,7 +347,7 @@ describe('mongo db middleware', function() {
             If we call done() in the middleware, we'll close the db connection, and then getOps will call _getOps()
             which will throw a "db connection closed" error.
            */
-          expect(middlewareSpy.calledOnceWith(sinon.match.object, sinon.match.func)).to.equal(true);
+          expect(middlewareSpy).to.have.been.calledOnceWith(sinon.match.object, sinon.match.func);
           done();
         });
       });


### PR DESCRIPTION
Recently the requirement has come up for middleware to be able to modify the options passed to Mongo, specifically for queries related to op submits. This adds the ability to check for `fields.$submit` from `sharedb` and pass `options.forSubmit = true` when invoking the middleware.

We'll also need to be able to pass a set of options to the mongo driver, which the middleware can modify. This PR includes those changes.

Added tests with this use case to ensure that the Mongo driver is called with the correct options, and that when middleware changes `findOptions`, we pass those to `find`.