### PR TITLE
⬆️ Bump `sharedb` to v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^2.6.3",
     "mongodb": "^2.1.2 || ^3.0.0 || ^4.0.0",
-    "sharedb": "^1.9.1"
+    "sharedb": "^1.9.1 || ^2.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
`sharedb` was recently bumped to [v2][1]. The only change was that it
officially dropped support for Node.js v10.

Therefore, consumers should be able to run `sharedb-mongo` with either
v1 or v2, which is now reflected in `package.json`.

[1]: https://github.com/share/sharedb/releases/tag/v2.0.0