### PR TITLE
💥 Update Node.js test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         node:
-        - 12
         - 14
         - 16
+        - 18
         mongodb:
         - 4.0
         - 4.2


### PR DESCRIPTION
Node.js 18 [has been released][1], and will be the next LTS version, so
we add this to our test matrix.

Node.js 12 has also been [end-of-lifed][2], and is dropped from the test
matrix.

[1]: https://nodejs.org/en/blog/announcements/v18-release-announce/
[2]: https://nodejs.org/en/about/releases/