### PR TITLE
🔒 Require secure `mongo@3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "async": "^2.6.3",
-    "mongodb": "^2.1.2 || ^3.0.0 || ^4.0.0",
+    "mongodb": "^2.1.2 || ^3.1.13 || ^4.0.0",
     "sharedb": "^1.9.1 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change addresses a security warning by requiring a patched version
of `mongo@3`.