### PR TITLE
GH Actions - Add manual triggering, update action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
         - 27017:27017
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
     - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
     - master
+  # Allow manually triggering tests
+  workflow_dispatch:
+    branches:
+    - master
 
 jobs:
   test:


### PR DESCRIPTION
https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

And upgrade to latest action versions, since old ones are deprecated