### PR TITLE
Pin tests' Mongo 4 version to mongodb@4.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "async": "^2.6.3",
-    "mongodb": "^2.1.2 || ^3.1.13 || ^4.0.0",
+    "mongodb": "^2.1.2 || ^3.1.13 || ~4.10.0",
     "sharedb": "^1.9.1 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
@@ -16,7 +16,7 @@
     "mocha": "^6.2.2",
     "mongodb2": "npm:mongodb@^2.1.2",
     "mongodb3": "npm:mongodb@^3.0.0",
-    "mongodb4": "npm:mongodb@^4.0.0",
+    "mongodb4": "npm:mongodb@4.10.0",
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
     "sharedb-mingo-memory": "^1.1.1",


### PR DESCRIPTION
See if mongodb@4.11.0 is the cause of failing tests:
https://github.com/share/sharedb-mongo/actions/runs/3322716943/jobs/5492132345

```
  1) db
       client query subscribe
         subscribed query gets update after reconnecting:
     Error: Attempted to check out a connection from closed connection pool (and Mocha's done() called multiple times)
      at wrapErrorData (node_modules/sharedb/lib/client/connection.js:266:13)
      at Connection.handleMessage (node_modules/sharedb/lib/client/connection.js:192:11)
      at StreamSocket.socket.onmessage (node_modules/sharedb/lib/client/connection.js:143:18)
      at /home/runner/work/sharedb-mongo/sharedb-mongo/node_modules/sharedb/lib/stream-socket.js:60:12
      at processTicksAndRejections (internal/process/task_queues.js:77:11)
```