### PR TITLE
Add skipPoll support for json1 ops, instead of throwing errors for them

### DIFF
--- a/index.js
+++ b/index.js
@@ -1044,10 +1044,44 @@ function getInnerFields(params, fields) {
 function opContainsAnyField(op, fields) {
   for (var i = 0; i < op.length; i++) {
     var component = op[i];
-    if (component.p.length === 0) {
+    if (Array.isArray(component.p)) {
+      // json0 op component:
+      //
+      // Each op component has its own array of `p` path segments from doc root.
+      if (component.p.length === 0) {
+        return true;
+      } else if (fields[component.p[0]]) {
+        return true;
+      }
+    } else if (typeof component === 'string') {
+      // json1 field descent from root:
+      //
+      // First string in top-level array means all subsequent operations will be
+      // underneath that top-level field, no need to continue iterating.
+      return fields[component];
+    } else if (hasOwnProperty(component, 'p') ||
+        hasOwnProperty(component, 'r') ||
+        hasOwnProperty(component, 'd') ||
+        hasOwnProperty(component, 'i') ||
+        hasOwnProperty(component, 'e')) {
+      // json1 root-level operation:
+      //
+      // If we encounter an operation at top level prior to encountering a string,
+      // (field descent) then the operation affects the entire document.
       return true;
-    } else if (fields[component.p[0]]) {
-      return true;
+    } else if (Array.isArray(component)) {
+      // json1 child operation list:
+      //
+      // In a canonical json1 op, if we encounter a child op prior to encountering
+      // a string (field descent), then the child should start with a field descent.
+      // If that weren't the case, the op would be pulled up to the top-level array.
+      var descendant = component;
+      while (typeof descendant[0] !== 'string') {
+        descendant = descendant[0];
+      }
+      if (fields[descendant[0]]) {
+        return true;
+      }
     }
   }
   return false;
@@ -1455,6 +1489,10 @@ function isPlainObject(value) {
       Object.getPrototypeOf(value) === null
     )
   );
+}
+
+function hasOwnProperty(obj, prop) {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
 }
 
 // Convert a simple map of fields that we want into a mongo projection. This


### PR DESCRIPTION
Resolves https://github.com/share/sharedb-mongo/issues/136

sharedb-mongo implements the optional `skipPoll` method as an optimization for query subscriptions, which lets it tell sharedb core to skip polling the DB if an op can't possibly affect a subscribed query.

The implementation had been specific to [json0 ops](https://github.com/ottypes/json0), and it would throw when encountering a [json1 op](https://github.com/ottypes/json1) due to the different op format, causing polling to always be skipped with json1.

This change adds `skipPoll` support for json1 ops, in the same way as it's done for json0 ops:
1. From the subscribed query, extract all top-level doc fields that are matched by the query.
2. Then, iterate over the op components.
3. If an op component changes the entire doc, then assume the query is affected and don't skip polling.
4. If the op component affects a queried field in any way, then don't skip polling. Otherwise, keep checking op components.

The implementation is a bit trickier for json1 ops. In contrast to json0, where an op component's subpath is present in a `p` path-segment array, json0 uses bare strings to indicate a "field descent", and a field descent from root level could be in different places:
```js
// Entire op under single top-level field, in this case setting doc.a.x and doc.a.y
const op1 = ['a', ['x', {i:1}], ['y', {i:2}]];

// Affecting two top-level fields, in this case moving doc.x to doc.z
const op2 = [['x', {p:0}], ['z', {d:0}]];

// Field descent after a whole-doc change
// In this case, initialize the whole doc to `{tags: []}`, then insert 'rock' into the tags array.
// The whole-doc insert means the later field insert doesn't matter for skipPoll.
const op3 = [{i:{tags:[]}}, 'tags', 0, {i:'rock'}];
```