### PR TITLE
💥 BREAKING: drop `mongodb@2` support

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,16 +126,6 @@ ShareDbMongo.prototype.getDbs = function(callback) {
     }, callback);
 };
 
-function isLegacyMongoClient(client) {
-  // mongodb 2.0 connect returns a DB object that also implements the
-  // functionality of client, such as `close()`. mongodb 3.0 connect returns a
-  // Client without the `collection()` method
-  return (
-    typeof client.collection === 'function' &&
-    typeof client.close === 'function'
-  );
-}
-
 ShareDbMongo.prototype._connect = function(mongo, options) {
   // Create the mongo connection client connections if needed
   //
@@ -148,17 +138,12 @@ ShareDbMongo.prototype._connect = function(mongo, options) {
   return Promise.all(connections).then(function(clients) {
     var mongoClient = clients[0];
     var mongoPollClient = clients[1];
-    var result = {
-      mongo: mongoClient,
+    return {
+      mongo: mongoClient.db(),
       mongoClient: mongoClient,
-      mongoPoll: mongoPollClient,
+      mongoPoll: mongoPollClient && mongoPollClient.db(),
       mongoPollClient: mongoPollClient
     };
-    if (!isLegacyMongoClient(mongoClient)) {
-      result.mongo = mongoClient.db();
-      if (mongoPollClient) result.mongoPoll = mongoPollClient.db();
-    }
-    return result;
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MongoDB database adapter for ShareDB",
   "main": "index.js",
   "dependencies": {
-    "mongodb": "^2.1.2 || ^3.1.13 || ^4.0.0 || ^5.0.0",
+    "mongodb": "^3.1.13 || ^4.0.0 || ^5.0.0",
     "sharedb": "^1.9.1 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
@@ -13,7 +13,6 @@
     "eslint": "^5.16.0",
     "eslint-config-google": "^0.13.0",
     "mocha": "^6.2.2",
-    "mongodb2": "npm:mongodb@^2.1.2",
     "mongodb3": "npm:mongodb@^3.0.0",
     "mongodb4": "npm:mongodb@^4.0.0",
     "mongodb5": "npm:mongodb@^5.0.0",
@@ -27,11 +26,10 @@
     "lint": "./node_modules/.bin/eslint --ignore-path .gitignore '**/*.js'",
     "lint:fix": "npm run lint -- --fix",
     "test": "mocha",
-    "test:mongodb2": "_SHAREDB_MONGODB_DRIVER=mongodb2 npm test",
     "test:mongodb3": "_SHAREDB_MONGODB_DRIVER=mongodb3 npm test",
     "test:mongodb4": "_SHAREDB_MONGODB_DRIVER=mongodb4 npm test",
     "test:mongodb5": "_SHAREDB_MONGODB_DRIVER=mongodb5 npm test",
-    "test:all": "npm run test:mongodb2 && npm run test:mongodb3 && npm run test:mongodb4 && npm run test:mongodb5",
+    "test:all": "npm run test:mongodb3 && npm run test:mongodb4 && npm run test:mongodb5",
     "test-cover": "nyc --temp-dir=coverage -r text -r lcov npm run test:all"
   },
   "repository": "git://github.com/share/sharedb-mongo.git",


### PR DESCRIPTION
The `mongodb@2` driver is not compatible with MongoDB v6. In order to add support for the latest database, we drop support for this old version of the `mongodb` driver.