### PR TITLE
👷‍♀️ Don't fail fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
     name: Node.js ${{ matrix.node }} + mongoDB ${{ matrix.mongodb }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node:
         - 14


### PR DESCRIPTION
Sometimes the build can be a bit flaky, and fast fail can be quite annoying in these cases.

This change sets [`fail-fast`][1] to `false` (it defaults `true`).

[1]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast