### PR TITLE
✅ Add `async` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "sharedb": "^1.9.1 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
+    "async": "^3.2.4",
     "chai": "^4.2.0",
     "coveralls": "^3.0.7",
     "eslint": "^5.16.0",


### PR DESCRIPTION
We incorrectly [removed `async`][1] from our dependencies, but we still import this library for our tests.

This change puts it back in our `devDependencies`

[1]: https://github.com/share/sharedb-mongo/pull/140/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7