### PR TITLE
✅ Fix `npm test`

### DIFF
--- a/test/test_mongo.js
+++ b/test/test_mongo.js
@@ -334,9 +334,10 @@ describe('mongo db', function() {
     });
 
     it('$mapReduce queries should work when allowJavaScriptQuery == true', function(done) {
-      if (process.env._SHAREDB_MONGODB_DRIVER === 'mongodb5') {
-        // This function was removed in mongodb5:
-        // https://github.com/mongodb/node-mongodb-native/pull/3511
+      // This function was removed in mongodb5:
+      // https://github.com/mongodb/node-mongodb-native/pull/3511
+      var mapReduceSupported = typeof this.db.mongo.collection('test').mapReduce === 'function';
+      if (!mapReduceSupported) {
         return done();
       }
       var snapshots = [


### PR DESCRIPTION
This is broken in a fresh install:

```
npm install
npm test
```

This is because `npm` will fetch `mongodb@5` (the latest it can), but running `npm test` without the `_SHAREDB_MONGODB_DRIVER` variable set means that the map reduce test still runs, when `mongodb@5` doesn't support it.

This change tweaks the test to check if the function is defined, instead of relying on the environment variable.