### PR TITLE
💥 Drop Node.js 14 and add Node.js 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         node:
-        - 14
         - 16
         - 18
+        - 20
         mongodb:
         - 4.0
         - 4.2


### PR DESCRIPTION
According to the Node.js [release schedule][1]:

 - v14 will be end-of-lifed on 30 April
 - v20 has been released

This change drops v14 from our test matrix, and adds v20.

[1]: https://nodejs.dev/en/about/releases/