### PR TITLE
Resolve memory leak when using cursor operations like $count in mongodb@4-6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1525,7 +1525,6 @@ var cursorOperationsMap = {
     cursor.map(fn)
       .toArray()
       .then(function(result) {
-        cursor.close();
         cb(null, result);
       }, cb);
   }

--- a/index.js
+++ b/index.js
@@ -1510,12 +1510,14 @@ var cursorOperationsMap = {
   $count: function(cursor, value, cb) {
     cursor.count()
       .then(function(result) {
+        cursor.close();
         cb(null, result);
       }, cb);
   },
   $explain: function(cursor, verbosity, cb) {
     cursor.explain(verbosity)
       .then(function(result) {
+        cursor.close();
         cb(null, result);
       }, cb);
   },
@@ -1523,6 +1525,7 @@ var cursorOperationsMap = {
     cursor.map(fn)
       .toArray()
       .then(function(result) {
+        cursor.close();
         cb(null, result);
       }, cb);
   }


### PR DESCRIPTION
Starting in Mongo Node driver `mongodb@4`, up through the latest version `mongodb@6`, using `cursor.count()` results in a memory leak. `mongodb@3` doesn't leak in the same situation.

The driver creates an implicit client session, but it doesn't automatically close the session when getting the results back from the server. Those unclosed sessions build up over time, causing a memory leak.

sharedb-mongo exposes document counting via a user passing the `$count: true` property on query objects, and it currently uses `cursor.count()`.

There are a couple ways sharedb-mongo could address the leak:
- Switch to `Collection#countDocuments()`, which is the recommended replacement for the deprecated `FindCursor#count()`. This is better long-term, but it's more work since we have to map things like `$limit` from using chained cursor calls over to the equivalent property in CountOptions, where appropriate.
- Explicitly close the cursor. Easy and safe, since the cursor is created inside sharedb-mongo and not exposed externally.

To resolve the leak more quickly, this change opts for the latter, explicitly closing the cursor for the "cursor operations" `$count`, `$explain`, and `$map`.

Thanks to @deongroenewald for the private report and repro case!

This also includes the changes in https://github.com/share/sharedb-mongo/pull/153 and https://github.com/share/sharedb-mongo/pull/154 - assuming those get merged first, I'll rebase this for a smaller diff.