### PR TITLE
Add dev dependency on rich-text for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mongodb6": "npm:mongodb@^6.0.0",
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
+    "rich-text": "^4.1.0",
     "sharedb-mingo-memory": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "sinon": "^9.2.4",
     "sinon-chai": "^3.7.0"


### PR DESCRIPTION
sharedb-mongo includes and runs all tests from sharedb core, and one of the core tests requires rich-text to be installed.