### PR TITLE
Fix $map query transform, add tests for $map and $explain

### DIFF
--- a/index.js
+++ b/index.js
@@ -1521,6 +1521,7 @@ var cursorOperationsMap = {
   },
   $map: function(cursor, fn, cb) {
     cursor.map(fn)
+      .toArray()
       .then(function(result) {
         cb(null, result);
       }, cb);

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mongodb6": "npm:mongodb@^6.0.0",
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
+    "rich-text": "^4.1.0",
     "sharedb-mingo-memory": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "sinon": "^9.2.4",
     "sinon-chai": "^3.7.0"

--- a/test/test_mongo.js
+++ b/test/test_mongo.js
@@ -108,6 +108,7 @@ describe('mongo db', function() {
       ];
       var query = {
         y: 2,
+        $sort: {x: 1},
         $map: function(doc) {
           return doc.x;
         }

--- a/test/test_mongo.js
+++ b/test/test_mongo.js
@@ -100,6 +100,60 @@ describe('mongo db', function() {
       });
     });
 
+    it('$map maps docs with output in extra', function(done) {
+      var snapshots = [
+        {type: 'json0', id: 'test1', v: 1, data: {x: 1, y: 1}},
+        {type: 'json0', id: 'test2', v: 1, data: {x: 2, y: 2}},
+        {type: 'json0', id: 'test3', v: 1, data: {x: 3, y: 2}}
+      ];
+      var query = {
+        y: 2,
+        $map: function(doc) {
+          return doc.x;
+        }
+      };
+
+      var db = this.db;
+      async.each(snapshots, function(snapshot, cb) {
+        db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, cb);
+      }, function(err) {
+        if (err) return done(err);
+        db.query('testcollection', query, null, null, function(err, results, extra) {
+          if (err) return done(err);
+
+          // Since $map can return non-docs, the output is delivered in extra.
+          expect(results).eql([]);
+          expect(extra).to.deep.equal([2, 3]);
+          done();
+        });
+      });
+    });
+
+    it('$explain delivers output in extra', function(done) {
+      var snapshots = [
+        {type: 'json0', id: 'test1', v: 1, data: {x: 1, y: 1}},
+        {type: 'json0', id: 'test2', v: 1, data: {x: 2, y: 2}},
+        {type: 'json0', id: 'test3', v: 1, data: {x: 3, y: 2}}
+      ];
+      var query = {$explain: true, y: 2};
+
+      var db = this.db;
+      async.each(snapshots, function(snapshot, cb) {
+        db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, cb);
+      }, function(err) {
+        if (err) return done(err);
+        db.query('testcollection', query, null, null, function(err, results, extra) {
+          if (err) return done(err);
+
+          expect(results).eql([]);
+          // Just check for the presence of an explain result. The specific structure
+          // could vary between Mongo versions.
+          expect(extra).to.be.an('object');
+          done();
+        });
+      });
+    });
+
     it('$sort, $skip and $limit should order, skip and limit', function(done) {
       var snapshots = [
         {type: 'json0', v: 1, data: {x: 1}, id: 'test1', m: null},


### PR DESCRIPTION
While adding tests for `$map` and `$explain` in queries in https://github.com/share/sharedb-mongo/pull/152, I found out that `$map` doesn't actually work. It just hangs since the cursor is never traversed for results.

This fixes `$map` by adding a `toArray()`. The results are delivered in the `extra` callback parameter, since the mapping function could map to something that's not a Mongo document, which would violate sharedb's assumptions around `results` being an array of Mongo docs.

I also added a test for `$explain`.