### PR TITLE
✅ Fix a slightly flaky test

### DIFF
--- a/test/test_mongo.js
+++ b/test/test_mongo.js
@@ -538,7 +538,7 @@ describe('mongo db connection', function() {
         db.queryPoll('testcollection', {}, null, function(err, results) {
           if (err) return done(err);
           expect(results.length).eql(1);
-          expect((new Date) - timeBeforeQuery).greaterThan(pollDelay);
+          expect((new Date) - timeBeforeQuery).greaterThanOrEqual(pollDelay);
           done();
         });
       });


### PR DESCRIPTION
Sometimes this test fails with:

```
  1) mongo db connection
       via url string with mongoPoll and pollDelay option
         delays queryPoll but not commit:

      Uncaught AssertionError: expected 1000 to be above 1000
      + expected - actual

      at /home/runner/work/sharedb-mongo/sharedb-mongo/test/test_mongo.js:541:48
      at /home/runner/work/sharedb-mongo/sharedb-mongo/index.js:133:2086
      at /home/runner/work/sharedb-mongo/sharedb-mongo/index.js:133:109
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

We don't care about the exact millisecond, so this change updates the assertion to `greaterThanOrEqual()`