### PR TITLE
✅ Allow the `allowedDriverRequire` global leaked by `mongodb`

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 --reporter spec
 --check-leaks
---globals Promise
+--globals Promise,allowedDriverRequire
 --timeout 18000
 --file test/setup.js


### PR DESCRIPTION
At the moment, running the test suite fails during the `before each` hook with:

```
Error: global leak detected: 'allowedDriverRequire'
```

This happens because the `mongodb` driver's `resolveRuntimeAdapters()` (added in v7.2.0) sets `globalThis.allowedDriverRequire` while it requires `os`, and then resets it to `false` in a `finally` block rather than deleting it. The lingering global property trips Mocha's `--check-leaks` detection.

Since we can't control the driver's behaviour, this change adds `allowedDriverRequire` to Mocha's `--globals` allow-list, alongside the `Promise` entry that exists for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
